### PR TITLE
Improve error handling for date filters and result collection

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -82,6 +82,8 @@ Do not merge or mark work complete if docs are stale.
 - `ImporterKind::detect()` inspects file headers for format auto-detection; `--format` CLI flag overrides auto-detect
 - Demo data is inserted directly into the DB (no CSV files); idempotency guard checks for existing account
 - Cash amounts are plain `f64` — negative = expense, positive = income
+- Date filters `--from`/`--to` must be supplied as a pair; providing only one is a hard error
+- Database row deserialization errors are propagated, never silently discarded
 
 ## Project Structure
 

--- a/src/categorizer.rs
+++ b/src/categorizer.rs
@@ -36,15 +36,13 @@ pub fn categorize_transactions(conn: &Connection) -> Result<CategorizeResult> {
                 row.get(4)?,
             ))
         })?
-        .filter_map(|r| r.ok())
-        .collect();
+        .collect::<std::result::Result<Vec<_>, _>>()?;
 
     let mut txn_stmt =
         conn.prepare("SELECT id, description FROM transactions WHERE category_id IS NULL")?;
     let flagged: Vec<(i64, String)> = txn_stmt
         .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
-        .filter_map(|r| r.ok())
-        .collect();
+        .collect::<std::result::Result<Vec<_>, _>>()?;
 
     let mut categorized = 0usize;
     let mut still_flagged = 0usize;

--- a/src/cli/accounts.rs
+++ b/src/cli/accounts.rs
@@ -27,8 +27,7 @@ pub fn list() -> Result<()> {
                 row.get(4)?,
             ))
         })?
-        .filter_map(|r| r.ok())
-        .collect();
+        .collect::<std::result::Result<Vec<_>, _>>()?;
 
     let mut table = Table::new();
     table.set_header(vec!["ID", "Name", "Type", "Institution", "Last Four"]);

--- a/src/cli/rules.rs
+++ b/src/cli/rules.rs
@@ -46,8 +46,7 @@ pub fn list() -> Result<()> {
                 row.get(6)?,
             ))
         })?
-        .filter_map(|r| r.ok())
-        .collect();
+        .collect::<std::result::Result<Vec<_>, _>>()?;
 
     let mut table = Table::new();
     table.set_header(vec!["ID", "Pattern", "Type", "Vendor", "Category", "Priority", "Hits"]);

--- a/src/db.rs
+++ b/src/db.rs
@@ -157,8 +157,8 @@ mod tests {
             .unwrap()
             .query_map([], |row| row.get(0))
             .unwrap()
-            .filter_map(|r| r.ok())
-            .collect();
+            .collect::<std::result::Result<Vec<_>, _>>()
+            .unwrap();
         for expected in &["accounts", "categories", "transactions", "rules", "imports", "reconciliations"] {
             assert!(tables.contains(&expected.to_string()), "missing table: {expected}");
         }

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -32,8 +32,7 @@ pub fn get_flagged_transactions(conn: &Connection) -> Result<Vec<FlaggedTxn>> {
                 account_name: row.get(4)?,
             })
         })?
-        .filter_map(|r| r.ok())
-        .collect();
+        .collect::<std::result::Result<Vec<_>, _>>()?;
     Ok(rows)
 }
 
@@ -49,8 +48,7 @@ pub fn get_categories(conn: &Connection) -> Result<Vec<CategoryChoice>> {
                 category_type: row.get(2)?,
             })
         })?
-        .filter_map(|r| r.ok())
-        .collect();
+        .collect::<std::result::Result<Vec<_>, _>>()?;
     Ok(rows)
 }
 


### PR DESCRIPTION
## Summary
This PR enhances error handling in the reports module by making date filter validation stricter and standardizing result collection patterns across the codebase. The changes ensure that partial date specifications (e.g., `--from` without `--to`) are rejected with clear error messages, and that database row deserialization errors are properly propagated rather than silently discarded.

## Key Changes

- **Date filter validation**: Modified `date_filter()` to return `Result<(String, Vec<String>)>` instead of a bare tuple. Now explicitly validates that `--from` and `--to` are supplied together, rejecting partial specifications with descriptive error messages.

- **Consistent error propagation**: Replaced all instances of `.filter_map(|r| r.ok()).collect()` with `.collect::<std::result::Result<Vec<_>, _>>()?` across multiple modules (`reports.rs`, `categorizer.rs`, `reviewer.rs`, `db.rs`, `cli/accounts.rs`, `cli/rules.rs`). This ensures database row deserialization errors are propagated to callers instead of being silently ignored.

- **Updated call sites**: Added `?` operator to all `date_filter()` calls in `get_pnl()`, `get_expense_breakdown()`, `get_tax_summary()`, `get_cashflow()`, `get_register()`, and `get_k1_prep()` to handle the new `Result` return type.

- **Test coverage**: Added three new tests validating date filter behavior:
  - `test_date_filter_rejects_from_without_to()`: Ensures `--from` alone is rejected
  - `test_date_filter_rejects_to_without_from()`: Ensures `--to` alone is rejected
  - `test_date_filter_accepts_both_from_and_to()`: Verifies valid date range filtering works correctly

- **Documentation**: Updated `CLAUDE.md` to document the date filter pairing requirement and the error propagation behavior.

## Implementation Details

The date filter now uses a `match` statement to explicitly handle all four combinations of `from_date` and `to_date` parameters, returning early with descriptive errors for invalid combinations. This prevents subtle bugs where users might accidentally filter by only one boundary.

The result collection pattern change is a safety improvement: instead of silently dropping rows that fail deserialization, errors are now propagated up the call stack where they can be properly handled or reported to the user.

https://claude.ai/code/session_01QkaxMFLqivr16XDUKCyMcM