### PR TITLE
fix: use make_date for interest payment and correct variance comment

### DIFF
--- a/src/cli/demo.rs
+++ b/src/cli/demo.rs
@@ -109,7 +109,7 @@ fn generate_transactions() -> Vec<DemoTxn> {
 
         // — Income: two Stripe transfers per month —
         let (base1, base2) = INCOME_BASES[idx % INCOME_BASES.len()];
-        // Small deterministic variation: +/- up to ~5% based on month index
+        // Small deterministic variation: +/- up to ~3% based on month index
         let vary = 1.0 + ((idx % 7) as f64 - 3.0) * 0.01;
         txns.push(DemoTxn {
             date: make_date(year, month, 3),
@@ -165,10 +165,9 @@ fn generate_transactions() -> Vec<DemoTxn> {
         }
 
         // — Interest payment on last day of month —
-        let last_day = clamp_day(year, month, 31);
         let interest = 1.50 + (idx % 5) as f64 * 0.25;
         txns.push(DemoTxn {
-            date: format!("{year:04}-{month:02}-{last_day:02}"),
+            date: make_date(year, month, 31),
             description: "INTEREST PAYMENT",
             amount: (interest * 100.0).round() / 100.0,
         });


### PR DESCRIPTION
## Summary

- Replace inline `clamp_day` + `format!` with `make_date(year, month, 31)` for the interest payment transaction, consistent with every other date construction in the function
- Fix variance comment from "~5%" to "~3%" to match the actual range of `(idx % 7 - 3) * 0.01`

Closes #49