### PR TITLE
feat: add business name header to text file exports

### DIFF
--- a/src/cli/report/text.rs
+++ b/src/cli/report/text.rs
@@ -13,7 +13,7 @@ fn with_header(company_name: &str, body: String) -> String {
     if company_name.is_empty() {
         body
     } else {
-        format!("{company_name}\n{body}")
+        format!("{company_name}\n\n{body}")
     }
 }
 
@@ -383,4 +383,19 @@ pub fn format_k1(data: &reports::K1PrepReport) -> String {
     }
 
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::with_header;
+
+    #[test]
+    fn with_header_prepends_when_set() {
+        assert_eq!(with_header("Acme Corp", "Report".into()), "Acme Corp\n\nReport");
+    }
+
+    #[test]
+    fn with_header_passthrough_when_empty() {
+        assert_eq!(with_header("", "Report".into()), "Report");
+    }
 }


### PR DESCRIPTION
## Summary

- Add `company_name` from DB metadata to the top of all text file exports, matching the existing PDF export behavior
- When `company_name` is empty or unset, output is unchanged (no blank line)
- Uses a `with_header` helper in the data-fetching wrappers to keep the pure format functions DB-free

Closes #52