### PR TITLE
fix: update stale walkthrough output for dynamic demo data

### DIFF
--- a/docs/walkthrough.md
+++ b/docs/walkthrough.md
@@ -65,12 +65,12 @@ $ nigel report flagged
 Flagged Transactions (84)
 
 ID  Date         Description                  Amount       Account
- 7  YYYY-MM-15   CHECK 1042                   -$2,400.00   BofA Checking
- 8  YYYY-MM-20   VENMO PAYMENT                  -$150.00   BofA Checking
- 9  YYYY-MM-25   COMCAST BUSINESS               -$129.99   BofA Checking
-10  YYYY-MM-28   STAPLES OFFICE SUPPLY           -$67.23   BofA Checking
-11  YYYY-MM-31   INTEREST PAYMENT                  $1.50   BofA Checking
-12  YYYY-MM-22   DOORDASH DELIVERY               -$28.45   BofA Checking
+--  YYYY-MM-15   CHECK 1042                   -$2,400.00   BofA Checking
+--  YYYY-MM-20   VENMO PAYMENT                  -$150.00   BofA Checking
+--  YYYY-MM-25   COMCAST BUSINESS               -$129.99   BofA Checking
+--  YYYY-MM-28   STAPLES OFFICE SUPPLY           -$67.23   BofA Checking
+--  YYYY-MM-DD   INTEREST PAYMENT                  $1.50   BofA Checking
+--  YYYY-MM-22   DOORDASH DELIVERY               -$28.45   BofA Checking
 ...
 ```
 


### PR DESCRIPTION
## Summary

- Replace hardcoded 2025 dates, transaction IDs, and counts throughout the walkthrough with values that reflect the dynamic 18-month demo data
- Update categorized/flagged counts (168/84), rule hit counts (18-month values), categorize results (35/49), and review counts
- Replace specific date/ID references with `YYYY-MM` placeholders where output varies by run date
- Add notes explaining that dates and IDs vary based on when the demo is run
- Update reconcile example with generic placeholders since balance is no longer predictable

Closes #50