### PR TITLE
Fix DB reliability: last_insert_rowid + busy timeout (#88, #89)

### DIFF
--- a/src/db.rs
+++ b/src/db.rs
@@ -124,6 +124,7 @@ const DEFAULT_CATEGORIES: &[(&str, Option<i64>, &str, Option<&str>, Option<&str>
 
 pub fn get_connection(db_path: &Path) -> Result<Connection> {
     let conn = Connection::open(db_path)?;
+    conn.busy_timeout(std::time::Duration::from_secs(5))?;
     conn.execute_batch("PRAGMA journal_mode=WAL; PRAGMA foreign_keys=ON;")?;
     Ok(conn)
 }

--- a/src/reviewer.rs
+++ b/src/reviewer.rs
@@ -96,7 +96,7 @@ pub fn apply_review(
                 "INSERT INTO rules (pattern, match_type, vendor, category_id) VALUES (?1, 'contains', ?2, ?3)",
                 rusqlite::params![pattern, vendor, category_id],
             )?;
-            Some(conn.last_insert_rowid())
+            Some(tx.last_insert_rowid())
         } else {
             None
         }


### PR DESCRIPTION
## Summary
- Fixed `apply_review` to use `tx.last_insert_rowid()` instead of `conn.last_insert_rowid()`
- Added 5-second SQLite busy timeout in `get_connection` to handle concurrent access gracefully

## Test plan
- [ ] `cargo test` passes
- [ ] `cargo clippy` clean

Closes #88
Closes #89