### PR TITLE
Fix params[0] panic in report functions (#84)

### DIFF
--- a/src/reports.rs
+++ b/src/reports.rs
@@ -147,8 +147,12 @@ pub fn get_expense_breakdown(
          GROUP BY c.name ORDER BY total ASC"
     );
     let mut stmt = conn.prepare(&sql)?;
+    let param_values: Vec<&dyn rusqlite::types::ToSql> = params
+        .iter()
+        .map(|p| p as &dyn rusqlite::types::ToSql)
+        .collect();
     let raw: Vec<(String, f64, i64)> = stmt
-        .query_map([&params[0]], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?
+        .query_map(param_values.as_slice(), |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?
         .collect::<std::result::Result<Vec<_>, _>>()?;
 
     let total: f64 = raw.iter().map(|(_, t, _)| t).sum();
@@ -170,7 +174,7 @@ pub fn get_expense_breakdown(
     );
     let mut vstmt = conn.prepare(&vendor_sql)?;
     let top_vendors: Vec<VendorItem> = vstmt
-        .query_map([&params[0]], |row| {
+        .query_map(param_values.as_slice(), |row| {
             Ok(VendorItem {
                 vendor: row.get(0)?,
                 total: row.get(1)?,
@@ -212,8 +216,12 @@ pub fn get_tax_summary(conn: &Connection, year: Option<i32>) -> Result<TaxSummar
          ORDER BY c.category_type DESC, c.tax_line"
     );
     let mut stmt = conn.prepare(&sql)?;
+    let param_values: Vec<&dyn rusqlite::types::ToSql> = params
+        .iter()
+        .map(|p| p as &dyn rusqlite::types::ToSql)
+        .collect();
     let items: Vec<TaxItem> = stmt
-        .query_map([&params[0]], |row| {
+        .query_map(param_values.as_slice(), |row| {
             Ok(TaxItem {
                 name: row.get(0)?,
                 tax_line: row.get(1)?,
@@ -253,8 +261,12 @@ pub fn get_cashflow(conn: &Connection, year: Option<i32>, month: Option<u32>) ->
          GROUP BY substr(t.date, 1, 7) ORDER BY month"
     );
     let mut stmt = conn.prepare(&sql)?;
+    let param_values: Vec<&dyn rusqlite::types::ToSql> = params
+        .iter()
+        .map(|p| p as &dyn rusqlite::types::ToSql)
+        .collect();
     let raw: Vec<(String, f64, f64)> = stmt
-        .query_map([&params[0]], |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?
+        .query_map(param_values.as_slice(), |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)))?
         .collect::<std::result::Result<Vec<_>, _>>()?;
 
     let mut months = Vec::new();


### PR DESCRIPTION
## Summary
- Fixed `get_expense_breakdown`, `get_tax_summary`, and `get_cashflow` to use `param_values.as_slice()` instead of `[&params[0]]`
- Matches the safe pattern already used by `get_pnl`, `get_register`, and `get_k1_prep`
- Prevents index-out-of-bounds panic when called with no date filter

## Test plan
- [ ] `cargo test` passes
- [ ] `cargo clippy` clean
- [ ] Verify `nigel report expenses`, `nigel report tax`, `nigel report cashflow` work without date flags

Closes #84