### PR TITLE
Fix scroll_to_today bounds in short terminals (#91)

### DIFF
--- a/src/browser.rs
+++ b/src/browser.rs
@@ -217,6 +217,7 @@ impl RegisterBrowser {
         }
 
         self.visible_count = vis.max(1);
+        self.selected = self.selected.min(self.visible_count.saturating_sub(1));
 
         // Table column constraints
         let widths: Vec<Constraint> = if narrow {


### PR DESCRIPTION
## Summary
- Clamped `selected` in `scroll_to_today` to prevent it exceeding the visible page area
- Prevents invisible/wrong row highlight in short terminals

## Test plan
- [x] `cargo test` passes (158 tests)
- [x] `cargo clippy` clean (no new warnings)
- [ ] Verify browser scroll behavior with small datasets

Closes #91