### PR TITLE
Add GitHub Actions CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,37 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  check:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt, clippy
+
+      - uses: Swatinem/rust-cache@v2
+
+      - name: Check formatting
+        run: cargo fmt --check
+
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Run tests
+        run: cargo test -- --test-threads=1
+
+      - name: Run tests (no default features)
+        run: cargo test --no-default-features -- --test-threads=1

--- a/src/cli/backup.rs
+++ b/src/cli/backup.rs
@@ -55,7 +55,7 @@ pub fn run(output: Option<String>) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::{get_connection, init_db, is_encrypted, open_connection, set_db_password};
+    use crate::db::{init_db, is_encrypted, open_connection, set_db_password};
 
     #[test]
     fn test_snapshot_preserves_encryption() {
@@ -65,17 +65,19 @@ mod tests {
 
         // Create encrypted source
         set_db_password(Some("secret".into()));
-        let conn = get_connection(&src_path).unwrap();
+        let conn = open_connection(&src_path, Some("secret")).unwrap();
         init_db(&conn).unwrap();
         drop(conn);
 
-        // Snapshot
-        let src_conn = get_connection(&src_path).unwrap();
+        // Snapshot (snapshot reads global password for dest encryption)
+        let src_conn = open_connection(&src_path, Some("secret")).unwrap();
         snapshot(&src_conn, &dst_path).unwrap();
         drop(src_conn);
 
-        // Verify backup is also encrypted
+        // Clear global password before assertions
         set_db_password(None);
+
+        // Verify backup is also encrypted
         assert!(is_encrypted(&dst_path).unwrap());
 
         // Verify backup opens with same password
@@ -93,7 +95,7 @@ mod tests {
         let dst_path = dir.path().join("backup.db");
 
         set_db_password(None);
-        let conn = get_connection(&src_path).unwrap();
+        let conn = open_connection(&src_path, None).unwrap();
         init_db(&conn).unwrap();
 
         snapshot(&conn, &dst_path).unwrap();

--- a/src/cli/dashboard.rs
+++ b/src/cli/dashboard.rs
@@ -847,7 +847,9 @@ fn do_export(idx: usize, year: Option<i32>, month: Option<String>) -> Result<Str
 
 fn do_text_export(idx: usize, year: Option<i32>, month: Option<String>) -> Result<String> {
     let year = year.or_else(|| Some(chrono::Local::now().year()));
-    let names = ["pnl", "expenses", "tax", "cashflow", "register", "flagged", "balance", "k1-prep"];
+    let names = [
+        "pnl", "expenses", "tax", "cashflow", "register", "flagged", "balance", "k1-prep",
+    ];
 
     if idx == 8 {
         // "All Reports" text export
@@ -860,7 +862,10 @@ fn do_text_export(idx: usize, year: Option<i32>, month: Option<String>) -> Resul
             ("expenses", super::report::text::expenses(None, year)),
             ("tax", super::report::text::tax(year)),
             ("cashflow", super::report::text::cashflow(None, year)),
-            ("register", super::report::text::register(None, year, None, None, None)),
+            (
+                "register",
+                super::report::text::register(None, year, None, None, None),
+            ),
             ("flagged", super::report::text::flagged()),
             ("balance", super::report::text::balance()),
             ("k1-prep", super::report::text::k1(year)),
@@ -1196,7 +1201,10 @@ pub fn run() -> Result<()> {
                             }
                             false
                         }
-                        DashboardScreen::ExportFormatPicker { report_idx, selection } => {
+                        DashboardScreen::ExportFormatPicker {
+                            report_idx,
+                            selection,
+                        } => {
                             let max_idx = EXPORT_FORMATS.len() - 1;
                             match key.code {
                                 KeyCode::Up => *selection = selection.saturating_sub(1),

--- a/src/effects.rs
+++ b/src/effects.rs
@@ -212,9 +212,8 @@ pub fn render_logo_reveal(
     let logo_width = max_logo_width();
     let gradient_width = 40.0;
 
-    let visible_set: Option<HashSet<(usize, usize)>> = reveal.map(|(order, count)| {
-        order[..count.min(order.len())].iter().copied().collect()
-    });
+    let visible_set: Option<HashSet<(usize, usize)>> =
+        reveal.map(|(order, count)| order[..count.min(order.len())].iter().copied().collect());
 
     let logo_lines: Vec<Line> = LOGO
         .iter()

--- a/src/main.rs
+++ b/src/main.rs
@@ -61,7 +61,10 @@ fn dispatch(command: Commands) -> error::Result<()> {
     // Prompt for password if database is encrypted (skip for init/demo which may create new DBs)
     if !matches!(
         command,
-        Commands::Init { .. } | Commands::Demo | Commands::Password { .. } | Commands::Completions { .. }
+        Commands::Init { .. }
+            | Commands::Demo
+            | Commands::Password { .. }
+            | Commands::Completions { .. }
     ) {
         let data_dir = crate::settings::get_data_dir();
         let db_path = data_dir.join("nigel.db");
@@ -148,7 +151,10 @@ fn dispatch(command: Commands) -> error::Result<()> {
                 priority,
             } => cli::rules::update(id, pattern, category, vendor, match_type, priority),
             RulesCommands::Delete { id } => cli::rules::delete(id),
-            RulesCommands::Test { pattern, match_type } => cli::rules::test(&pattern, &match_type),
+            RulesCommands::Test {
+                pattern,
+                match_type,
+            } => cli::rules::test(&pattern, &match_type),
         },
         Commands::Review { id } => cli::review::run(id),
         Commands::Report { command } => cli::report::dispatch(command),

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -25,9 +25,9 @@ pub fn get_schema_version(conn: &Connection) -> Result<u32> {
         [],
         |row| row.get::<_, String>(0),
     ) {
-        Ok(v) => v.parse::<u32>().map_err(|_| {
-            crate::error::NigelError::Other(format!("invalid schema_version: {v}"))
-        }),
+        Ok(v) => v
+            .parse::<u32>()
+            .map_err(|_| crate::error::NigelError::Other(format!("invalid schema_version: {v}"))),
         Err(rusqlite::Error::QueryReturnedNoRows) => Ok(0),
         Err(e) => Err(e.into()),
     }

--- a/src/reports.rs
+++ b/src/reports.rs
@@ -943,7 +943,7 @@ mod tests {
     fn test_cashflow_cross_year_boundary() {
         let (_dir, conn) = test_db();
         seed_transactions(&conn); // 2025 transactions
-        // Add a 2024 transaction that should NOT affect 2025 prior balance
+                                  // Add a 2024 transaction that should NOT affect 2025 prior balance
         let acct: i64 = conn
             .query_row("SELECT id FROM accounts WHERE name = 'Test'", [], |r| {
                 r.get(0)


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` running `cargo fmt --check`, `cargo clippy -- -D warnings`, `cargo test`, and `cargo test --no-default-features` on both ubuntu-latest and macos-latest
- Tests run with `--test-threads=1` to avoid race conditions on the global `DB_PASSWORD` mutex shared by encryption-related tests
- Fix pre-existing `cargo fmt` violations across `dashboard.rs`, `effects.rs`, `main.rs`, `migrations.rs`, and `reports.rs`
- Fix backup test race condition by using `open_connection` with explicit password arguments instead of relying solely on global state

## Test plan
- Verified `cargo fmt --check` passes locally
- Verified `cargo clippy -- -D warnings` passes locally with zero warnings
- Verified `cargo test -- --test-threads=1` passes (201 tests, 15 integration tests)
- Verified `cargo test --no-default-features -- --test-threads=1` passes (194 tests, 15 integration tests)
- CI workflow will self-validate on this PR

Closes #71