### PR TITLE
chore: add Claude pre-commit hook for fmt and test checks

### DIFF
--- a/.claude/hooks/pre-commit-checks.sh
+++ b/.claude/hooks/pre-commit-checks.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+# Claude PreToolUse hook: runs cargo fmt --check and cargo test before git commits and PR merges.
+# Blocks the action if formatting or tests fail.
+
+INPUT=$(cat)
+COMMAND=$(echo "$INPUT" | jq -r '.tool_input.command // empty')
+CWD=$(echo "$INPUT" | jq -r '.cwd // empty')
+
+# Only intercept git commit and gh pr merge commands
+if ! echo "$COMMAND" | grep -qE '(git commit|gh pr merge)'; then
+  exit 0
+fi
+
+# Run checks from the working directory
+cd "$CWD" || exit 0
+
+# Check formatting on staged .rs files only (avoids blocking on pre-existing issues)
+STAGED_RS=$(git diff --cached --name-only --diff-filter=ACM -- '*.rs' 2>/dev/null)
+if [ -n "$STAGED_RS" ]; then
+  FMT_OUTPUT=$(cargo fmt --check 2>&1)
+  if [ $? -ne 0 ]; then
+    # Only fail if the fmt diff involves staged files
+    STAGED_FMT_FAIL=false
+    for f in $STAGED_RS; do
+      if echo "$FMT_OUTPUT" | grep -q "$f"; then
+        STAGED_FMT_FAIL=true
+        break
+      fi
+    done
+    if [ "$STAGED_FMT_FAIL" = true ]; then
+      echo "Blocked: cargo fmt --check failed on staged files. Run 'cargo fmt' first." >&2
+      exit 2
+    fi
+  fi
+fi
+
+# Run tests (no-default-features to match CI)
+if ! cargo test --no-default-features -- --test-threads=1 2>/dev/null; then
+  echo "Blocked: cargo test failed. Fix failing tests before committing." >&2
+  exit 2
+fi
+
+exit 0

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,3 +1,16 @@
 {
-  "hooks": {}
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": ".claude/hooks/pre-commit-checks.sh",
+            "timeout": 300000
+          }
+        ]
+      }
+    ]
+  }
 }


### PR DESCRIPTION
## Summary
- Adds a PreToolUse hook that runs `cargo fmt --check` and `cargo test` before `git commit` and `gh pr merge` commands
- Only checks formatting on staged `.rs` files to avoid blocking on pre-existing issues in untouched files
- Blocks the action with a clear error message if either check fails

## Test plan
- [x] Hook passes through non-commit Bash commands without running checks
- [x] Hook catches formatting issues on staged files
- [x] Hook runs tests matching CI configuration (`--no-default-features --test-threads=1`)
- [x] All 250 unit tests + 20 integration tests pass
- [x] `cargo fmt --check` passes