### PR TITLE
Add goodbye screen on exit and fix splash dissolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,7 @@
 - **Interactive TUI dashboard** — running `nigel` with no arguments launches a full-screen dashboard with YTD P&L, account balances, monthly income/expense bar chart, and single-key command menu
 - **First-run onboarding** — guided setup screen with animated logo, collects user name, business name, optional password, and offers demo/fresh/load options
 - **Splash screen** — rainbow gradient ASCII logo with floating particle effects on launch
+- **Goodbye screen** — reverse logo animation with "Goodbye!" text and particle effects on dashboard quit
 - **Database encryption** — SQLCipher encryption with `nigel password set/change/remove` commands; password prompted at launch, never persisted to disk
 - **Schema migration system** — sequential versioned migrations run automatically on startup with savepoint transactions
 - **Import enhancements** — `--dry-run` preview mode, malformed row tracking, generic CSV format auto-detection
@@ -35,6 +36,7 @@
 - BofA importers refactored to share parsing helpers
 
 ### Fixed
+- Splash screen no longer dissolves out before transitioning to dashboard — logo stays solid after reveal
 - BofA CSV parsing when cardholder names contain commas
 - Scroll-to-today bounds in short terminals
 - Report parameter panics on empty date filters

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,8 +21,9 @@ Nigel — a Rust CLI bookkeeping tool to replace QuickBooks for small consultanc
 - **Reconcile Screen:** `cli/reconcile_manager.rs` — inline TUI form for account reconciliation; account selector + month/balance input; shows reconciled/discrepancy result
 - **Load Screen:** `cli/load_manager.rs` — inline TUI form for switching data directories; validates path and triggers dashboard reload
 - **Reports:** `cli/report/` — unified report command with `--mode view|export`, `--format pdf|text`, and `--output` flags; `mod.rs` dispatches to `view.rs` (interactive ratatui views), `text.rs` (comfy_table formatting), or `export.rs` (PDF export); non-TTY automatically falls back to plain text stdout. `TableReportView` supports interactive date navigation: Left/Right arrows page between periods, `m` toggles month/year granularity; each report declares its `DateGranularity` (MonthAndYear, YearOnly, or None)
-- **Effects:** `effects.rs` — shared pastel rainbow gradient palette, `gradient_color()` interpolation, `Particle` struct with `new()`/`seeded()`/`tick()`/`is_dead()`, `pre_seed_particles()`, and `tick_particles()` helpers; used by splash, onboarding, and snake screens
+- **Effects:** `effects.rs` — shared pastel rainbow gradient palette, `gradient_color()` interpolation, `Particle` struct with `new()`/`seeded()`/`tick()`/`is_dead()`, `pre_seed_particles()`, and `tick_particles()` helpers; used by splash, goodbye, onboarding, and snake screens
 - **Splash:** `cli/splash.rs` — 1.5-second splash screen shown on app launch (skipped during first-run onboarding); displays Nigel ASCII logo with rainbow gradient text and pre-seeded floating particle background; dismissable by any keypress
+- **Goodbye:** `cli/goodbye.rs` — 1.2-second farewell screen shown when quitting the dashboard; displays Nigel ASCII logo with "Goodbye!" text, plays the reverse of the splash reveal animation (characters disappear), with particle background; dismissable by any keypress
 - **Modules:** `categorizer.rs` (rules engine), `reviewer.rs` (review data layer), `reports.rs` (P&L, expenses, tax, cashflow, balance, flagged, register, K-1 prep), `browser.rs` (interactive register browser via ratatui with row selection, inline category/vendor editing, flag toggling, scroll navigation, text wrapping, and incremental text search), `reconciler.rs` (monthly reconciliation), `pdf.rs` (PDF rendering via printpdf, feature-gated)
 - **Migrations:** `migrations.rs` — sequential schema migration runner; `MIGRATIONS` array of `(version, description, up_fn)`; runs inside `init_db()` after table creation; each migration executes in a savepoint transaction; version tracked in `metadata` table under `schema_version` key; v1 is the no-op baseline for existing 0.1.x databases; v2 adds `csv_profiles` table for generic CSV column mappings
 - **Data flow:** CSV/XLSX import → automatic pre-import DB snapshot (`<data_dir>/snapshots/`) → format auto-detect via `ImporterKind::detect()` → duplicate detection → auto-categorize via rules → flag unknowns for review → generate reports
@@ -163,6 +164,7 @@ src/
     browse.rs           # nigel browse (interactive browsers)
     snake.rs            # Snake game easter egg (ratatui, accessible from dashboard)
     splash.rs           # Splash screen (1.5s animated logo + particles, shown on launch)
+    goodbye.rs          # Goodbye screen (reverse logo animation + particles, shown on quit)
     export.rs           # PDF export helpers (per-function feature-gated behind "pdf")
     reconcile.rs        # nigel reconcile
     load.rs             # nigel load (switch data directory)

--- a/src/cli/dashboard.rs
+++ b/src/cli/dashboard.rs
@@ -1336,8 +1336,11 @@ pub fn run() -> Result<()> {
 
         match exit {
             Err(e) => return Err(e),
-            Ok(true) => return Ok(()), // quit
-            Ok(false) => continue,     // reload (data directory changed)
+            Ok(true) => {
+                let _ = super::goodbye::run();
+                return Ok(());
+            }
+            Ok(false) => continue, // reload (data directory changed)
         }
     }
 }

--- a/src/cli/goodbye.rs
+++ b/src/cli/goodbye.rs
@@ -1,0 +1,244 @@
+use std::time::{Duration, Instant};
+
+use crossterm::event::{self, Event, KeyEventKind};
+use ratatui::{
+    layout::{Alignment, Constraint, Layout},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::Paragraph,
+    Frame,
+};
+
+use crate::effects::{self, Particle, LOGO};
+use crate::error::Result;
+
+const GOODBYE_DURATION: Duration = Duration::from_millis(1200);
+const TICK_INTERVAL: Duration = Duration::from_millis(50);
+const HOLD_MS: f64 = 400.0;
+const UNREVEAL_MS: f64 = 800.0;
+
+struct Goodbye {
+    phase: f64,
+    particles: Vec<Particle>,
+    width: u16,
+    height: u16,
+    start: Instant,
+    reveal_order: Vec<(usize, usize)>,
+}
+
+impl Goodbye {
+    fn new() -> Self {
+        let (width, height) = crossterm::terminal::size().unwrap_or((80, 24));
+        Self {
+            phase: 0.0,
+            particles: effects::pre_seed_particles(width, height),
+            width,
+            height,
+            start: Instant::now(),
+            reveal_order: effects::logo_reveal_order(),
+        }
+    }
+
+    fn is_expired(&self) -> bool {
+        self.start.elapsed() >= GOODBYE_DURATION
+    }
+
+    fn tick(&mut self) {
+        self.phase += 1.0 / 70.0;
+        effects::tick_particles(&mut self.particles, self.width, self.height);
+    }
+
+    fn chars_visible_at(&self, elapsed_ms: f64) -> usize {
+        let total_chars = self.reveal_order.len();
+        if elapsed_ms < HOLD_MS {
+            total_chars
+        } else {
+            let progress = ((elapsed_ms - HOLD_MS) / UNREVEAL_MS).min(1.0);
+            ((1.0 - progress) * total_chars as f64) as usize
+        }
+    }
+
+    fn opacity_at(elapsed_ms: f64) -> f64 {
+        if elapsed_ms < HOLD_MS {
+            1.0
+        } else {
+            let progress = ((elapsed_ms - HOLD_MS) / UNREVEAL_MS).min(1.0);
+            1.0 - progress
+        }
+    }
+
+    fn draw(&mut self, frame: &mut Frame) {
+        let area = frame.area();
+        self.width = area.width;
+        self.height = area.height;
+
+        let elapsed_ms = self.start.elapsed().as_secs_f64() * 1000.0;
+
+        effects::render_particles(&self.particles, frame, area);
+
+        let logo_height = LOGO.len() as u16;
+        let goodbye_line_height = 2; // blank line + "Goodbye!"
+        let total_height = logo_height + goodbye_line_height;
+        let [_top, content_area, _bottom] = Layout::vertical([
+            Constraint::Fill(1),
+            Constraint::Length(total_height),
+            Constraint::Fill(1),
+        ])
+        .areas(area);
+
+        let [logo_area, goodbye_area] = Layout::vertical([
+            Constraint::Length(logo_height),
+            Constraint::Length(goodbye_line_height),
+        ])
+        .areas(content_area);
+
+        let chars_visible = self.chars_visible_at(elapsed_ms);
+
+        effects::render_logo_reveal(
+            self.phase,
+            frame,
+            logo_area,
+            Some((&self.reveal_order, chars_visible)),
+        );
+
+        let goodbye_opacity = Self::opacity_at(elapsed_ms);
+
+        let base_color = effects::gradient_color(self.phase);
+        let faded_color = if let Color::Rgb(r, g, b) = base_color {
+            Color::Rgb(
+                (r as f64 * goodbye_opacity) as u8,
+                (g as f64 * goodbye_opacity) as u8,
+                (b as f64 * goodbye_opacity) as u8,
+            )
+        } else {
+            base_color
+        };
+
+        let goodbye_text = Line::from(Span::styled(
+            "Goodbye!",
+            Style::default()
+                .fg(faded_color)
+                .add_modifier(Modifier::BOLD),
+        ));
+        frame.render_widget(
+            Paragraph::new(vec![Line::raw(""), goodbye_text]).alignment(Alignment::Center),
+            goodbye_area,
+        );
+    }
+}
+
+/// Run the goodbye screen. Blocks for up to 1.2 seconds; any keypress dismisses early.
+pub fn run() -> Result<()> {
+    let mut goodbye = Goodbye::new();
+    let mut terminal = ratatui::init();
+
+    let result: Result<()> = loop {
+        if let Err(e) = terminal.draw(|frame| goodbye.draw(frame)) {
+            break Err(e.into());
+        }
+
+        if goodbye.is_expired() {
+            break Ok(());
+        }
+
+        if event::poll(TICK_INTERVAL)? {
+            match event::read() {
+                Err(e) => break Err(e.into()),
+                Ok(Event::Key(key)) => {
+                    if key.kind == KeyEventKind::Press {
+                        break Ok(());
+                    }
+                }
+                _ => {}
+            }
+        }
+
+        goodbye.tick();
+    };
+
+    ratatui::restore();
+    result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn goodbye_starts_not_expired() {
+        let goodbye = Goodbye::new();
+        assert!(!goodbye.is_expired());
+    }
+
+    #[test]
+    fn goodbye_has_pre_seeded_particles() {
+        let goodbye = Goodbye::new();
+        assert_eq!(goodbye.particles.len(), effects::MAX_PARTICLES * 2);
+    }
+
+    #[test]
+    fn goodbye_tick_advances_phase() {
+        let mut goodbye = Goodbye::new();
+        let phase_before = goodbye.phase;
+        goodbye.tick();
+        assert!(goodbye.phase > phase_before);
+    }
+
+    #[test]
+    fn goodbye_duration_is_1200ms() {
+        assert_eq!(GOODBYE_DURATION, Duration::from_millis(1200));
+    }
+
+    #[test]
+    fn reveal_order_contains_all_logo_chars() {
+        let goodbye = Goodbye::new();
+        let width = effects::max_logo_width();
+        let expected: usize = LOGO
+            .iter()
+            .map(|line| {
+                format!("{:<width$}", line, width = width)
+                    .chars()
+                    .filter(|c| *c != ' ')
+                    .count()
+            })
+            .sum();
+        assert_eq!(goodbye.reveal_order.len(), expected);
+    }
+
+    #[test]
+    fn chars_visible_starts_at_full() {
+        let goodbye = Goodbye::new();
+        assert_eq!(goodbye.chars_visible_at(0.0), goodbye.reveal_order.len());
+    }
+
+    #[test]
+    fn chars_visible_decreases_after_hold() {
+        let goodbye = Goodbye::new();
+        let total = goodbye.reveal_order.len();
+        let visible = goodbye.chars_visible_at(HOLD_MS + UNREVEAL_MS / 2.0);
+        assert!(visible < total);
+        assert!(visible > 0);
+    }
+
+    #[test]
+    fn chars_visible_reaches_zero_at_end() {
+        let goodbye = Goodbye::new();
+        assert_eq!(goodbye.chars_visible_at(HOLD_MS + UNREVEAL_MS), 0);
+    }
+
+    #[test]
+    fn opacity_starts_at_full() {
+        assert_eq!(Goodbye::opacity_at(0.0), 1.0);
+    }
+
+    #[test]
+    fn opacity_fades_during_unreveal() {
+        let opacity = Goodbye::opacity_at(HOLD_MS + UNREVEAL_MS / 2.0);
+        assert!(opacity > 0.0 && opacity < 1.0);
+    }
+
+    #[test]
+    fn opacity_reaches_zero_at_end() {
+        assert_eq!(Goodbye::opacity_at(HOLD_MS + UNREVEAL_MS), 0.0);
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -8,6 +8,7 @@ pub mod category_manager;
 pub mod dashboard;
 pub mod demo;
 pub mod export;
+pub mod goodbye;
 pub mod import;
 pub mod import_manager;
 pub mod init;

--- a/src/cli/splash.rs
+++ b/src/cli/splash.rs
@@ -12,7 +12,6 @@ use crate::error::Result;
 const SPLASH_DURATION: Duration = Duration::from_millis(1500);
 const TICK_INTERVAL: Duration = Duration::from_millis(50);
 const REVEAL_MS: f64 = 500.0;
-const DISSOLVE_MS: f64 = 400.0;
 
 struct Splash {
     phase: f64,
@@ -51,8 +50,6 @@ impl Splash {
         self.height = area.height;
 
         let elapsed_ms = self.start.elapsed().as_secs_f64() * 1000.0;
-        let total_ms = SPLASH_DURATION.as_secs_f64() * 1000.0;
-        let remaining_ms = total_ms - elapsed_ms;
 
         effects::render_particles(&self.particles, frame, area);
 
@@ -67,9 +64,6 @@ impl Splash {
         let total_chars = self.reveal_order.len();
         let chars_visible = if elapsed_ms < REVEAL_MS {
             let progress = elapsed_ms / REVEAL_MS;
-            (progress * total_chars as f64) as usize
-        } else if remaining_ms < DISSOLVE_MS {
-            let progress = (remaining_ms / DISSOLVE_MS).max(0.0);
             (progress * total_chars as f64) as usize
         } else {
             total_chars


### PR DESCRIPTION
## Summary
- Adds a farewell screen when quitting the dashboard — Nigel ASCII logo with "Goodbye!" text, reverse reveal animation, and particle background
- Fixes splash screen dissolve-out so logo stays solid before transitioning to dashboard

Closes #152

## Test plan
- [ ] Launch app, verify splash reveals in and stays solid (no dissolve-out)
- [ ] Press `q` to quit, verify goodbye screen shows logo + "Goodbye!" with reverse animation
- [ ] Press any key during goodbye to dismiss early
- [ ] Run `cargo test` — all 285 tests pass
- [ ] Run `cargo clippy` — no new warnings